### PR TITLE
read/write/store all files as binary data with unified underlying type

### DIFF
--- a/include/mqlqd/fclient.hpp
+++ b/include/mqlqd/fclient.hpp
@@ -126,7 +126,7 @@ protected:
    * @return -1 on error   - and errno msg is logged to indicate the error.
    * @return -2 on send() -> 0 - nothing to send etc.
    */
-  template <typename T>
+  template <typename T = file::File::char_type>
   [[nodiscard]] int
   send_loop(int fd, void const* buf, size_t len);
 

--- a/include/mqlqd/file.hpp
+++ b/include/mqlqd/file.hpp
@@ -30,6 +30,12 @@ mkdir(fs::path const& dpath, fs::perms const& perms = fs::perms::group_all, bool
 class File final
 {
 public:
+  // to read/write/store all files as binary data with the unified underlying type
+  // across the project code base and across devices.
+  // XXX: u8 unsigned char type makes printing binary file contents unbearable!
+  // using char_type = u8;
+  using char_type = char;
+
   inline static constexpr auto openmode_r{
     std::ios::in  | std::ios::binary | std::ios::ate
   };
@@ -87,7 +93,7 @@ public:
 public:
   fs::path    m_fpath{ };
   std::size_t m_block_size{ 0 };
-  char       *m_block{ nullptr }; // memory block -> contiguous chunk of memory.
+  char_type  *m_block{ nullptr }; // memory block -> contiguous chunk of memory.
 };
 
 } // namespace file

--- a/include/mqlqd/file.hpp
+++ b/include/mqlqd/file.hpp
@@ -30,10 +30,14 @@ mkdir(fs::path const& dpath, fs::perms const& perms = fs::perms::group_all, bool
 class File final
 {
 public:
-  // to read/write/store all files as binary data with the unified underlying type
-  // across the project code base and across devices.
-  // XXX: u8 unsigned char type makes printing binary file contents unbearable!
-  // using char_type = u8;
+  /**
+   * to read/write/store all files as binary data with the unified underlying type
+   * across the project code base and across devices.
+   * NOTE: tried other types, specifically: u8 - unsigned char type => break the logic:
+   *      printing/writing binary file contents. (send/recv maybe also, but not sure!)
+   *      Currently i do not see any benefit in wasting time on making this possible using u8.
+   *      Probably some extra handling required, which only overcomplicate code. (so why bother?)
+   */
   using char_type = char;
 
   inline static constexpr auto openmode_r{

--- a/include/mqlqd/fserver.hpp
+++ b/include/mqlqd/fserver.hpp
@@ -153,7 +153,7 @@ protected:
    * @return -1 on error   - and errno msg is logged to indicate the error.
    * @return -2 on recv() -> 0 - orderly shutdown etc. ref: recv(2).
    */
-  template <typename T>
+  template <typename T = file::File::char_type>
   [[nodiscard]] int
   recv_loop(int fd, void *buf, size_t len);
 

--- a/src/client/fclient.cpp
+++ b/src/client/fclient.cpp
@@ -112,7 +112,7 @@ Fclient::send_files(std::vector<file::File> const& vfiles)
 Fclient::send_file(file::File const& file)
 {
   log_g.msg(LL::INFO, fmt::format("INSIDE send_file() : {}", file));
-  m_rc = send_loop<char>(m_fd, file.m_block, file.m_block_size);
+  m_rc = send_loop(m_fd, file.m_block, file.m_block_size);
   if (m_rc != 0) {
     log_g.msg(LL::ERRO, fmt::format("[FAIL] send_file() in send_loop() -> {} : {}", m_rc, file));
     return m_rc;

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -168,7 +168,10 @@ File::write()
   }
 
   try {
-    ofs << m_block;
+    // NOTE: for loop is necessary for writing full contents of the binary file!
+    for (size_t i = 0; i < m_block_size; i++) {
+      ofs << m_block[i];
+    }
     log_g.msg(LL::STAT, fmt::format("Contents of the memory block were written to the file:\n\t{}",
                                     m_fpath.c_str()));
   } catch(std::exception const& err) {

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -152,7 +152,7 @@ File::write()
     return 33;
   }
   // open file for writing
-  std::ofstream ofs(m_fpath, openmode_w);
+  std::basic_fstream<char_type> ofs(m_fpath, openmode_w);
   // TODO: reinspect checks
   if (!ofs) {
     log_g.msg(LL::ERRO, "can not open output file!");
@@ -185,7 +185,7 @@ int File::heap_alloc() noexcept
   // but maybe there is the benefit in proper using of the raw pointers?
   // It is easy to rewrite if requested!
   try {
-    m_block = { new char[m_block_size]{} };
+    m_block = { new char_type[m_block_size]{} };
     if (!m_block) {
       log_g.msg(LL::CRIT, "[FAIL] File::heap_alloc() memory block == nullptr!");
       return 30;
@@ -227,7 +227,7 @@ int File::fcontent()
   int rc{ is_r(m_fpath) }; // return code
   if (rc != 0) return rc;
   // open file for reading
-  std::ifstream ifs(m_fpath, openmode_r);
+  std::basic_fstream<char_type> ifs(m_fpath, openmode_r);
   // invariants & validation/safety checks
   if (!ifs) {
     log_g.msg(LL::ERRO, "can not open input file!");
@@ -298,7 +298,10 @@ void File::print_fcontent() const noexcept
 #if FILE_CONTENTS_BOUNDARY
   std::cerr << ">>> [BEG] " << m_fpath << " - file content >>>" << '\n';
 #endif // FILE_CONTENTS_BOUNDARY
-  std::cout << m_block;
+  // NOTE: for loop is necessary for printing full contents of the binary file!
+  for (size_t i = 0; i < m_block_size; i++) {
+    fmt::print("{:c}", m_block[i]);
+  }
 #if FILE_CONTENTS_BOUNDARY
   std::cerr << "<<< [END] " << m_fpath << " - file content <<<" << '\n';
 #endif // FILE_CONTENTS_BOUNDARY

--- a/src/daemon/fserver.cpp
+++ b/src/daemon/fserver.cpp
@@ -138,7 +138,7 @@ Fserver::recv_file(const size_t i)
   m_rc = file.heap_alloc();
   if (m_rc != 0) return m_rc;
 
-  m_rc = recv_loop<char>(m_fd_con, file.m_block, file.m_block_size);
+  m_rc = recv_loop(m_fd_con, file.m_block, file.m_block_size);
   if (m_rc != 0) {
     log_g.msg(LL::ERRO, fmt::format("[FAIL] recv_file() in recv_loop() -> {} : {}", m_rc, file));
     return m_rc;


### PR DESCRIPTION
read/write/store all files as binary data with unified underlying type
-> char_type, across the project code base and across devices.

u8 - unsigned char type makes printing binary file contents unbearable! => so currently basic char type is used

probably some advanced technique needed in order to print binary file contents,
if stored as u8 - interpret unsigned char as basic char, or smth like that,
which looks very inconvenient & not necessary...?